### PR TITLE
Fix linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
     - $HOME/gopath/pkg/mod         # Cache the Go modules
 
 before_script:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.6
 
 jobs:
   include:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ generate:
 	go run github.com/onosproject/helmit/cmd/helmit-generate ./build/helmit-generate/generate.yaml ./pkg/kubernetes
 
 test: # @HELP run the unit tests and source code validation
-test: license_check build deps 
+test: linters license_check build deps
 	go test github.com/onosproject/helmit/pkg/...
 	go test github.com/onosproject/helmit/cmd/...
 

--- a/pkg/cli/benchmark.go
+++ b/pkg/cli/benchmark.go
@@ -16,10 +16,11 @@ package cli
 
 import (
 	"errors"
-	"github.com/onosproject/helmit/pkg/job"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/onosproject/helmit/pkg/job"
 
 	"github.com/onosproject/helmit/pkg/benchmark"
 	"github.com/onosproject/helmit/pkg/util/random"
@@ -137,7 +138,7 @@ func runBenchCommand(cmd *cobra.Command, args []string) error {
 			ID:              benchID,
 			Executable:      executable,
 			Image:           image,
-			ImagePullPolicy: corev1.PullPolicy(pullPolicy),
+			ImagePullPolicy: pullPolicy,
 			Context:         context,
 			ValueFiles:      valueFiles,
 			Values:          values,

--- a/pkg/cli/simulate.go
+++ b/pkg/cli/simulate.go
@@ -16,13 +16,14 @@ package cli
 
 import (
 	"errors"
-	"github.com/onosproject/helmit/pkg/job"
-	"github.com/onosproject/helmit/pkg/simulation"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/onosproject/helmit/pkg/job"
+	"github.com/onosproject/helmit/pkg/simulation"
 
 	"github.com/onosproject/helmit/pkg/util/random"
 	"github.com/spf13/cobra"
@@ -156,7 +157,7 @@ func runSimulateCommand(cmd *cobra.Command, args []string) error {
 		Config: &job.Config{
 			ID:              simID,
 			Image:           image,
-			ImagePullPolicy: corev1.PullPolicy(pullPolicy),
+			ImagePullPolicy: pullPolicy,
 			Executable:      executable,
 			Context:         context,
 			ValueFiles:      valueFiles,

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -15,9 +15,7 @@
 package cli
 
 import (
-	"bytes"
 	"errors"
-	"github.com/onosproject/helmit/pkg/job"
 	"go/build"
 	"math/rand"
 	"os"
@@ -25,6 +23,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/onosproject/helmit/pkg/job"
 
 	"github.com/onosproject/helmit/pkg/util/logging"
 
@@ -167,28 +167,6 @@ func buildBinary(pkgPath, binPath string) error {
 	env = append(env, "GOOS=linux", "CGO_ENABLED=0")
 	build.Env = env
 	return build.Run()
-}
-
-func isKindCluster() (bool, error) {
-	kubeConfig := os.Getenv("KUBECONFIG")
-	if kubeConfig == "" {
-		return false, nil
-	}
-
-	buffer := bytes.NewBuffer(nil)
-	cmd := exec.Command("kind", "get", "kubeconfig-path")
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = buffer
-	if err := cmd.Run(); err != nil {
-		return false, nil
-	}
-	kubeConfigPaths := strings.Split(strings.TrimSuffix(buffer.String(), "\n"), "\n")
-	for _, path := range kubeConfigPaths {
-		if kubeConfig == path {
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 func parseFiles(files []string) (map[string][]string, error) {

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint
 package helm
 
 import (
@@ -19,8 +20,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// ChartClient is a Helm chart client
-type ChartClient interface {
+// HelmChartClient is a Helm chart client
+type HelmChartClient interface {
 	// Charts returns a list of charts in the namespace
 	Charts() []*HelmChart
 
@@ -55,7 +56,7 @@ func newChart(name string, repo []string, namespace string, client *kubernetes.C
 
 // HelmChart is a Helm chart
 type HelmChart struct {
-	ReleaseClient
+	HelmReleaseClient
 	namespace  string
 	client     *kubernetes.Clientset
 	config     *action.Configuration

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -19,8 +19,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// HelmChartClient is a Helm chart client
-type HelmChartClient interface {
+// ChartClient is a Helm chart client
+type ChartClient interface {
 	// Charts returns a list of charts in the namespace
 	Charts() []*HelmChart
 
@@ -55,7 +55,7 @@ func newChart(name string, repo []string, namespace string, client *kubernetes.C
 
 // HelmChart is a Helm chart
 type HelmChart struct {
-	HelmReleaseClient
+	ReleaseClient
 	namespace  string
 	client     *kubernetes.Clientset
 	config     *action.Configuration

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint
 package helm
 
 import (
@@ -64,8 +65,8 @@ func getConfig(namespace string) (*action.Configuration, error) {
 
 // HelmClient is a Helm client
 type HelmClient interface {
-	ChartClient
-	ReleaseClient
+	HelmChartClient
+	HelmReleaseClient
 
 	// Namespace returns the client for the given namespace
 	Namespace(namespace string) HelmClient

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -15,10 +15,11 @@
 package helm
 
 import (
+	"log"
+
 	"github.com/onosproject/helmit/pkg/kubernetes/config"
 	"helm.sh/helm/v3/pkg/action"
 	"k8s.io/client-go/kubernetes"
-	"log"
 )
 
 var clients = make(map[string]HelmClient)
@@ -63,8 +64,8 @@ func getConfig(namespace string) (*action.Configuration, error) {
 
 // HelmClient is a Helm client
 type HelmClient interface {
-	HelmChartClient
-	HelmReleaseClient
+	ChartClient
+	ReleaseClient
 
 	// Namespace returns the client for the given namespace
 	Namespace(namespace string) HelmClient

--- a/pkg/helm/release.go
+++ b/pkg/helm/release.go
@@ -18,6 +18,10 @@ import (
 	"bytes"
 	"encoding/csv"
 	"fmt"
+	"os"
+	"reflect"
+	"strings"
+
 	"github.com/iancoleman/strcase"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
@@ -29,15 +33,12 @@ import (
 	helm "helm.sh/helm/v3/pkg/kube"
 	"helm.sh/helm/v3/pkg/release"
 	"k8s.io/client-go/kubernetes"
-	"os"
-	"reflect"
-	"strings"
 )
 
 var settings = cli.New()
 
-// HelmReleaseClient is a Helm release client
-type HelmReleaseClient interface {
+// ReleaseClient is a Helm release client
+type ReleaseClient interface {
 	// Releases returns a list of releases in the namespace
 	Releases() []*HelmRelease
 

--- a/pkg/helm/release.go
+++ b/pkg/helm/release.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint
 package helm
 
 import (
@@ -37,8 +38,8 @@ import (
 
 var settings = cli.New()
 
-// ReleaseClient is a Helm release client
-type ReleaseClient interface {
+// HelmReleaseClient is a Helm release client
+type HelmReleaseClient interface {
 	// Releases returns a list of releases in the namespace
 	Releases() []*HelmRelease
 

--- a/pkg/job/runner.go
+++ b/pkg/job/runner.go
@@ -18,6 +18,9 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"path"
+	"time"
+
 	"github.com/onosproject/helmit/pkg/kubernetes"
 	"github.com/onosproject/helmit/pkg/util/files"
 	"github.com/onosproject/helmit/pkg/util/logging"
@@ -28,8 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/watch"
-	"path"
-	"time"
 )
 
 const clusterRole = "kube-test-cluster"
@@ -53,7 +54,7 @@ type Runner struct {
 	server bool
 }
 
-// Run runs the given job
+// RunJob runs the given job
 func (n *Runner) RunJob(job *Job) (int, error) {
 	if err := n.StartJob(job); err != nil {
 		return 0, err

--- a/pkg/test/coordinator.go
+++ b/pkg/test/coordinator.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 
 	"github.com/onosproject/helmit/pkg/job"
-	"github.com/onosproject/helmit/pkg/kubernetes"
 	"github.com/onosproject/helmit/pkg/registry"
 	"google.golang.org/grpc"
 )
@@ -36,7 +35,6 @@ func newCoordinator(config *Config) (*Coordinator, error) {
 
 // Coordinator coordinates workers for suites of tests
 type Coordinator struct {
-	client kubernetes.Client
 	config *Config
 }
 

--- a/pkg/test/coordinator.go
+++ b/pkg/test/coordinator.go
@@ -17,13 +17,14 @@ package test
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
+	"sync"
+
 	"github.com/onosproject/helmit/pkg/job"
 	"github.com/onosproject/helmit/pkg/kubernetes"
 	"github.com/onosproject/helmit/pkg/registry"
 	"google.golang.org/grpc"
-	"os"
-	"strconv"
-	"sync"
 )
 
 // newCoordinator returns a new test coordinator
@@ -162,6 +163,10 @@ func (t *WorkerTask) Run() (int, error) {
 		Suite: t.config.Suites[0],
 		Tests: t.config.Tests,
 	})
+
+	if err != nil {
+		return 0, err
+	}
 
 	status, err := t.runner.WaitForExit(job)
 	if err != nil {

--- a/pkg/util/files/echo.go
+++ b/pkg/util/files/echo.go
@@ -17,12 +17,13 @@ package files
 import (
 	"errors"
 	"fmt"
+	"os"
+
 	"github.com/onosproject/helmit/pkg/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
-	"os"
 )
 
 // Echo returns a new echo client
@@ -60,7 +61,7 @@ func (o *EchoOptions) To(filename string) *EchoOptions {
 	return o
 }
 
-// To configures the copy destination pod
+// On To configures the copy destination pod
 func (o *EchoOptions) On(pod string, container ...string) *EchoOptions {
 	o.pod = pod
 	if len(container) > 0 {

--- a/pkg/util/files/echo.go
+++ b/pkg/util/files/echo.go
@@ -61,7 +61,7 @@ func (o *EchoOptions) To(filename string) *EchoOptions {
 	return o
 }
 
-// On To configures the copy destination pod
+// On configures the copy destination pod
 func (o *EchoOptions) On(pod string, container ...string) *EchoOptions {
 	o.pod = pod
 	if len(container) > 0 {


### PR DESCRIPTION
@kuujo 

there are some linter errors and the name of interfaces should be changed to avoid adding "helm" to the beginning of them. Any suggestion? The linter itself suggests to remove helm at the beginning of interface/struct names or we should rename the package. 