### PR TITLE
Ensure core group is an empty string in generated code

### DIFF
--- a/pkg/kubernetes/codegen/resource.tpl
+++ b/pkg/kubernetes/codegen/resource.tpl
@@ -19,7 +19,11 @@ import (
 )
 
 var {{ $resource.Types.Kind }} = resource.Kind{
+    {{- if eq $resource.Kind.Group "core" }}
+	Group:   "",
+    {{- else }}
 	Group:   {{ $resource.Kind.Group | quote }},
+	{{- end }}
 	Version: {{ $resource.Kind.Version | quote }},
 	Kind:    {{ $resource.Kind.Kind | quote }},
 	{{- if $resource.Kind.Scoped }}

--- a/pkg/kubernetes/core/v1/configmap.go
+++ b/pkg/kubernetes/core/v1/configmap.go
@@ -10,7 +10,7 @@ import (
 )
 
 var ConfigMapKind = resource.Kind{
-	Group:   "core",
+	Group:   "",
 	Version: "v1",
 	Kind:    "ConfigMap",
 	Scoped:  true,

--- a/pkg/kubernetes/core/v1/endpoints.go
+++ b/pkg/kubernetes/core/v1/endpoints.go
@@ -10,7 +10,7 @@ import (
 )
 
 var EndpointsKind = resource.Kind{
-	Group:   "core",
+	Group:   "",
 	Version: "v1",
 	Kind:    "Endpoints",
 	Scoped:  true,

--- a/pkg/kubernetes/core/v1/node.go
+++ b/pkg/kubernetes/core/v1/node.go
@@ -10,7 +10,7 @@ import (
 )
 
 var NodeKind = resource.Kind{
-	Group:   "core",
+	Group:   "",
 	Version: "v1",
 	Kind:    "Node",
 	Scoped:  true,

--- a/pkg/kubernetes/core/v1/pod.go
+++ b/pkg/kubernetes/core/v1/pod.go
@@ -10,7 +10,7 @@ import (
 )
 
 var PodKind = resource.Kind{
-	Group:   "core",
+	Group:   "",
 	Version: "v1",
 	Kind:    "Pod",
 	Scoped:  true,

--- a/pkg/kubernetes/core/v1/secret.go
+++ b/pkg/kubernetes/core/v1/secret.go
@@ -10,7 +10,7 @@ import (
 )
 
 var SecretKind = resource.Kind{
-	Group:   "core",
+	Group:   "",
 	Version: "v1",
 	Kind:    "Secret",
 	Scoped:  true,

--- a/pkg/kubernetes/core/v1/service.go
+++ b/pkg/kubernetes/core/v1/service.go
@@ -10,7 +10,7 @@ import (
 )
 
 var ServiceKind = resource.Kind{
-	Group:   "core",
+	Group:   "",
 	Version: "v1",
 	Kind:    "Service",
 	Scoped:  true,

--- a/test/test.go
+++ b/test/test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/onosproject/helmit/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
 
 // ChartTestSuite is a test for chart deployment
@@ -56,6 +57,21 @@ func (s *ChartTestSuite) TestLocalInstall(t *testing.T) {
 	pods, err = deployment.Pods().List()
 	assert.NoError(t, err)
 	assert.Len(t, pods, 1)
+	pod := pods[0]
+	err = pod.Delete()
+	assert.NoError(t, err)
+
+	err = deployment.Wait(1 * time.Minute)
+	assert.NoError(t, err)
+
+	pods, err = deployment.Pods().List()
+	assert.NoError(t, err)
+	assert.Len(t, pods, 1)
+	assert.NotEqual(t, pod.Name, pods[0].Name)
+
+	services, err := client.CoreV1().Services().List()
+	assert.NoError(t, err)
+	assert.Len(t, services, 1)
 }
 
 // TestRemoteInstall tests a remote chart installation


### PR DESCRIPTION
Resources in the `core/v1` API version are not correctly filtered. This PR ensures the `Kind`'s `Group` field is empty for `core` resources.